### PR TITLE
Adding OLDA section to TC39X linker script

### DIFF
--- a/TC39X/ee_tc_gcc_flash.ld
+++ b/TC39X/ee_tc_gcc_flash.ld
@@ -255,6 +255,9 @@ MEMORY
 
   EDMEM           (w!xp): org = 0x99000000, len = 4M
   EDMEM_nc        (w!xp): org = 0xB9000000, len = 4M
+
+/* OLDA address range */
+  OLDA_nc         (w!xp): org = 0xAFE00000, len = 0x7FFFF
 }
 
 /* Map local memory address to a global address */
@@ -681,6 +684,12 @@ SECTIONS
     *(.lmubss)
     *(.lmubss.*)
   } > LMU_SRAM_nc
+
+/* OLDA section */
+  CORE_SEC(.OLDA_BASE_MEM) (NOLOAD) :
+  {
+    *(.OLDA_BASE_MEM)
+  } > OLDA_nc
 }
 
 /* Core Private Sections */


### PR DESCRIPTION
For AUTOSAR ARTI implementation in OpenErika, we need the OLDA section to be defined in the linker script.